### PR TITLE
FPSourceController cancel operations

### DIFF
--- a/FPPicker/FPSourceController.m
+++ b/FPPicker/FPSourceController.m
@@ -65,6 +65,7 @@ static const NSInteger ROW_HEIGHT = 44;
 
 - (void)backButtonAction
 {
+    [[self httpRequestOperationQueue] cancelAllOperations];
     [self.navigationController popViewControllerAnimated:YES];
 }
 


### PR DESCRIPTION
This PR adds a line of code to cancel all operations in FPSourceController's HTTP request operation queue when the user taps the back button.  Without it, it's possible that pending HTTP operations continue downloading (and complete), even after the user has tapped back.
