### PR TITLE
Fixed issue with selecting Instagram images.

### DIFF
--- a/FPPicker Resources/Assets/allowedUrlPrefix.plist
+++ b/FPPicker Resources/Assets/allowedUrlPrefix.plist
@@ -73,5 +73,7 @@
 	<string>https://login.yahoo.com/m</string>
 	<string>https://login.yahoo.com/ylc</string>
 	<string>https://www.flickr.com/ms/signin/yahoo/</string>
+	<string>https://s-static.ak.facebook.com/connect/xd_arbiter/</string>
+	<string>https://www.facebook.com/connect/ping</string>
 </array>
 </plist>


### PR DESCRIPTION
Based on the log files, it appears that Instagram changed their auth flow and are now using some endpoints from Facebook. I was able to fix it by adding the following urls to the allowedUrlPrefix.plist:
https://s-static.ak.facebook.com/connect/xd_arbiter/
https://www.facebook.com/connect/ping

related issue: https://github.com/Ink/ios-picker/issues/56
