### PR TITLE
fix sharedApplication issues for iOS9

### DIFF
--- a/FPPicker/Platforms/iOS/FPPickerController.m
+++ b/FPPicker/Platforms/iOS/FPPickerController.m
@@ -74,16 +74,7 @@
     {
         [self initializeProperties];
 
-        CGFloat statusBarHeight = CGRectGetHeight([UIApplication sharedApplication].statusBarFrame);
-
-        if (statusBarHeight < 0.0001)
-        {
-            self.hasStatusBar = NO;
-        }
-        else
-        {
-            self.hasStatusBar = YES;
-        }
+        self.hasStatusBar = YES;
     }
 
     return self;
@@ -159,11 +150,6 @@
 - (void)    imagePickerController:(FPImagePickerController *)picker
     didFinishPickingMediaWithInfo:(NSDictionary *)info
 {
-    if (self.hasStatusBar)
-    {
-        [[UIApplication sharedApplication] setStatusBarHidden:NO];
-    }
-
     /* resizing the thumbnail */
 
     UIImage *originalImage, *editedImage, *imageToSave;
@@ -311,11 +297,6 @@
 
 - (void)imagePickerControllerDidCancel:(UIImagePickerController *)picker
 {
-    if (self.hasStatusBar)
-    {
-        [[UIApplication sharedApplication] setStatusBarHidden:NO];
-    }
-
     // The user chose to cancel when using the camera.
 
     [picker dismissViewControllerAnimated:YES

--- a/FPPicker/Platforms/iOS/FPSearchController.m
+++ b/FPPicker/Platforms/iOS/FPSearchController.m
@@ -37,7 +37,7 @@
     }
 
     UISearchBar *searchBar = [[UISearchBar alloc] initWithFrame:CGRectMake(0,
-                                                                           [UIApplication sharedApplication].statusBarFrame.size.height,
+                                                                           0,
                                                                            320,
                                                                            44)];
 

--- a/FPPicker/Platforms/iOS/FPSourceController.m
+++ b/FPPicker/Platforms/iOS/FPSourceController.m
@@ -650,16 +650,6 @@ static const CGFloat ROW_HEIGHT = 44.0;
                                              animated:YES];
 
                     [self.navigationController popViewControllerAnimated:YES];
-
-                    UIAlertView *message;
-
-                    message = [[UIAlertView alloc] initWithTitle:@"Internet Connection"
-                                                         message:@"You aren't connected to the internet so we can't get your files."
-                                                        delegate:nil
-                                               cancelButtonTitle:@"OK"
-                                               otherButtonTitles:nil];
-
-                    [message show];
                 }
                 else
                 {
@@ -872,14 +862,6 @@ static const CGFloat ROW_HEIGHT = 44.0;
         error.code == kCFURLErrorUnsupportedURL)
     {
         [self.navigationController popViewControllerAnimated:YES];
-
-        UIAlertView *message = [[UIAlertView alloc] initWithTitle:@"Internet Connection"
-                                                          message:@"You aren't connected to the internet so we can't get your files."
-                                                         delegate:nil
-                                                cancelButtonTitle:@"OK"
-                                                otherButtonTitles:nil];
-
-        [message show];
     }
 
     if (error.code == kCFURLErrorUserCancelledAuthentication)
@@ -1136,16 +1118,6 @@ static const CGFloat ROW_HEIGHT = 44.0;
                 error.code == kCFURLErrorUnsupportedURL)
             {
                 [self.navigationController popViewControllerAnimated:YES];
-
-                UIAlertView *message;
-
-                message = [[UIAlertView alloc] initWithTitle:@"Internet Connection"
-                                                     message:@"You aren't connected to the internet so we can't get your files."
-                                                    delegate:nil
-                                           cancelButtonTitle:@"OK"
-                                           otherButtonTitles:nil];
-
-                [message show];
             }
 
             dispatch_async(dispatch_get_main_queue(), ^{
@@ -1287,18 +1259,6 @@ static const CGFloat ROW_HEIGHT = 44.0;
                                                              NSError *error) {
         [MBProgressHUD hideAllHUDsForView:self.navigationController.view
                                  animated:YES];
-
-        NSLog(@"error: %@", error);
-
-        UIAlertView *message;
-
-        message = [[UIAlertView alloc] initWithTitle:@"Logout Failure"
-                                             message:@"Hmm. We weren't able to logout."
-                                            delegate:nil
-                                   cancelButtonTitle:@"OK"
-                                   otherButtonTitles:nil];
-
-        [message show];
     };
 
     AFHTTPRequestOperation *operation;

--- a/FPPicker/Platforms/iOS/FPSourceListController.m
+++ b/FPPicker/Platforms/iOS/FPSourceListController.m
@@ -203,22 +203,9 @@
                 imgPicker.disableFrontCameraLivePreviewMirroring = picker.disableFrontCameraLivePreviewMirroring;
             }
 
-            [[UIApplication sharedApplication] setStatusBarHidden:YES];
-
             [self presentViewController:imgPicker
                                animated:YES
                              completion:nil];
-        }
-        else
-        {
-            UIAlertView *alertView;
-
-            alertView = [[UIAlertView alloc] initWithTitle:@"No Camera Available"
-                                                   message:@"This device doesn't seem to have a camera available."
-                                                  delegate:nil
-                                         cancelButtonTitle:@"OK"
-                                         otherButtonTitles:nil];
-            [alertView show];
         }
     }
     else if (source.identifier == FPSourceCameraRoll)

--- a/FPPicker/Platforms/iOS/UIApplication+FPAppDimensions.m
+++ b/FPPicker/Platforms/iOS/UIApplication+FPAppDimensions.m
@@ -12,7 +12,7 @@
 
 + (CGSize)FPCurrentSize
 {
-    return [self FPSizeInOrientation:[UIApplication sharedApplication].statusBarOrientation];
+    return CGSizeMake(0, 0);
 }
 
 + (CGSize)FPSizeInOrientation:(UIInterfaceOrientation)orientation


### PR DESCRIPTION
The “sharedApplication” is not useable in an extension as UIAlertView initWithTitle constructor has been deprecated and is no longer in warning status.

Like I stated in my email to support, this might not be the exact way for you guys to "fix" the code for iOS9, though this is what we did to get our app submitted to iTunes. Maybe you can take the ideas of this PR, and make them your own.

Your call... just let us know :+1: 
