### PR TITLE
Fix #100 where uploading fails when using AFNetworking 2.6.1

### DIFF
--- a/FPPicker/Shared/FPAPIClient.m
+++ b/FPPicker/Shared/FPAPIClient.m
@@ -26,16 +26,6 @@
     return _sharedClient;
 }
 
-- (AFHTTPRequestOperation *)HTTPRequestOperationWithRequest:(NSURLRequest *)request
-                                                    success:(void (^)(AFHTTPRequestOperation *, id))success
-                                                    failure:(void (^)(AFHTTPRequestOperation *, NSError *))failure
-{
-    //AFHTTPRequestSerializer adds User-Agent header to request
-    NSURLRequest *serializedRequest = [[AFHTTPRequestSerializer serializer] requestBySerializingRequest:request withParameters:nil error:nil];
-
-    return [super HTTPRequestOperationWithRequest:serializedRequest success:success failure:failure];
-}
-
 - (AFHTTPRequestOperation *)POST:(NSString *)URLString
                       parameters:(id)parameters
              usingOperationQueue:(NSOperationQueue *)operationQueue


### PR DESCRIPTION
The behavior of AFHTTPRequestSerializer changed in AFNetworking 2.6.1 which causes the HTTPBody of requests to be discarded. Specifically, FPAPIClient.m was calling copying a request with AFHTTPRequestSerialized twice. The first time in `-[FPAPIClient POST:parameters:usingOperationQueue:success:failure:]`, then again in the override in `HTTPRequestOperationWithRequest:Success:failure`.

Due to the change in behavior in AFNetworking (https://github.com/AFNetworking/AFNetworking/pull/2868/files) if a request has an empty query string, the new request created by AFHTTPRequestSerializer will also have an empty body, which is what was happening the second time that the request was copied with AFHTTPRequestSerializer.

It seems that FPAPIClient was relying on undefined behavior of the AFHTTPRequestSerializer initializer; namely that it would copy the HTTPBody if the HTTPBody was present.

Rather than try to get a fix made to AFNetworking, I think it's better to workaround the problem here by removing the override for HTTPRequestOperationWithRequest since the function seems to serve no purpose. The original commit 72f6fa0 does not shed any light on what exactly it's trying to accomplish with the user agent.
