### PR TITLE
Fix #108 FPSourceControllerDelegate delegate is called twice

### DIFF
--- a/FPPicker/Platforms/iOS/FPLocalController.m
+++ b/FPPicker/Platforms/iOS/FPLocalController.m
@@ -615,6 +615,7 @@ typedef void (^FPLocalUploadAssetProgressBlock)(float progress);
     NSLog(@"Asset: %@", asset);
 
     [FPUtils asyncFetchAssetThumbnailFromPHAsset:asset
+                    ensureCompletionIsCalledOnce:YES
                                       completion: ^(UIImage *image) {
         FPMediaInfo *mediaInfo = [FPMediaInfo new];
 

--- a/FPPicker/Platforms/iOS/FPUtils+iOS.h
+++ b/FPPicker/Platforms/iOS/FPUtils+iOS.h
@@ -34,10 +34,23 @@ typedef void (^FPFetchPHAssetImageBlock)(UIImage *image);
 
 /*!
     Asynchronously fetches the thumbnail UIImage representing the given asset.
+    Note: the completionBlock might be called multiple times, see documentation for
+    -[PHImageManager requestImageForAsset:targetSize:contentMode:options:resultHandler:]
 
     @returns void
  */
 + (void)asyncFetchAssetThumbnailFromPHAsset:(PHAsset *)asset
+                                 completion:(FPFetchPHAssetImageBlock)completionBlock;
+
+
+/*!
+    Asynchronously fetches the thumbnail UIImage representing the given asset.
+    The completion block is guaranted to be called only once
+
+    @returns void
+ */
++ (void)asyncFetchAssetThumbnailFromPHAsset:(PHAsset *)asset
+               ensureCompletionIsCalledOnce:(BOOL)ensureOnce
                                  completion:(FPFetchPHAssetImageBlock)completionBlock;
 
 /*!


### PR DESCRIPTION
The FPSourceControllerDelegate didPickMediaWithInfo delegate method is called twice because +[PHImageManager requestImageForAsset:], when called asynchronously, may call its completion handler more than once. The fix is to to set synchronous=YES to indicate that the completion block should be called exactly once.

This fix is scoped so that it will not affect the other callers of asyncFetchAssetThumbnailFromPHAsset.
