### PR TITLE
Prevent objects that are already percent encoded from being double encoded

### DIFF
--- a/FPPicker/Shared/FPLibrary.h
+++ b/FPPicker/Shared/FPLibrary.h
@@ -43,6 +43,13 @@
                         andMimetypes:(NSArray *)mimetypes
                          cachePolicy:(NSURLRequestCachePolicy)policy;
 
++ (NSURLRequest *)requestForLoadPath:(NSString *)loadpath
+                          withFormat:(NSString *)type
+                         queryString:(NSString *)queryString
+                        andMimetypes:(NSArray *)mimetypes
+                         cachePolicy:(NSURLRequestCachePolicy)policy
+                     shouldURLEncode:(BOOL)encode;
+
 #ifdef FPLibrary_protected
 
 + (void)uploadLocalURLToFilepicker:(NSURL *)localURL

--- a/FPPicker/Shared/FPLibrary.m
+++ b/FPPicker/Shared/FPLibrary.m
@@ -283,12 +283,12 @@
                         andMimetypes:(NSArray *)mimetypes
                          cachePolicy:(NSURLRequestCachePolicy)policy
 {
-    [self requestForLoadPath:loadpath
-                  withFormat:type
-                 queryString:queryString
-                andMimetypes:mimetypes
-                 cachePolicy:policy
-             shouldURLEncode:YES];
+    return [self requestForLoadPath:loadpath
+                         withFormat:type
+                        queryString:queryString
+                       andMimetypes:mimetypes
+                        cachePolicy:policy
+                    shouldURLEncode:YES];
 }
 
 + (NSURLRequest *)requestForLoadPath:(NSString *)loadpath

--- a/FPPicker/Shared/FPLibrary.m
+++ b/FPPicker/Shared/FPLibrary.m
@@ -25,7 +25,8 @@
                                           withFormat:@"data"
                                          queryString:nil
                                         andMimetypes:source.mimetypes
-                                         cachePolicy:NSURLRequestReloadRevalidatingCacheData];
+                                         cachePolicy:NSURLRequestReloadRevalidatingCacheData
+                                     shouldURLEncode:NO];
 
     NSString *tempPath = [NSTemporaryDirectory() stringByAppendingPathComponent:[FPUtils genRandStringLength:20]];
 
@@ -282,6 +283,21 @@
                         andMimetypes:(NSArray *)mimetypes
                          cachePolicy:(NSURLRequestCachePolicy)policy
 {
+    [self requestForLoadPath:loadpath
+                  withFormat:type
+                 queryString:queryString
+                andMimetypes:mimetypes
+                 cachePolicy:policy
+             shouldURLEncode:YES];
+}
+
++ (NSURLRequest *)requestForLoadPath:(NSString *)loadpath
+                          withFormat:(NSString *)type
+                         queryString:(NSString *)queryString
+                        andMimetypes:(NSArray *)mimetypes
+                         cachePolicy:(NSURLRequestCachePolicy)policy
+                     shouldURLEncode:(BOOL)encode;
+{
     FPSession *fpSession = [FPSession sessionForFileUploads];
     fpSession.mimetypes = mimetypes;
 
@@ -289,7 +305,14 @@
     NSURLComponents *urlComponents = [NSURLComponents componentsWithString:fpBASE_URL];
 
     urlComponents.query = queryString;
-    urlComponents.path = [NSString stringWithFormat:@"/api/path%@", loadpath];
+    if (encode)
+    {
+        urlComponents.path = [NSString stringWithFormat:@"/api/path%@", loadpath];
+    }
+    else
+    {
+        urlComponents.percentEncodedPath = [NSString stringWithFormat:@"/api/path%@", loadpath];
+    }
 
     NSArray *queryItems = @[
         [NSURLQueryItem queryItemWithName:@"format" value:type],


### PR DESCRIPTION
Fixes #121

Note that this highlights what appears to be a server-side bug. See #121 for conversation. 
